### PR TITLE
Fix data segment length incorrect

### DIFF
--- a/src/hyperloglog_counting.c
+++ b/src/hyperloglog_counting.c
@@ -123,7 +123,11 @@ hll_cnt_ctx_t *hll_cnt_init(const void *obuf, uint32_t len_or_k, uint8_t hf)
 
     if (buf) {
         // initial bitmap was given
-        uint8_t log2m = buf ? num_of_trail_zeros(len_or_k) : len_or_k;
+        if(len_or_k <= 3){
+          return NULL;
+        }
+        uint32_t data_segment_size = len_or_k - 3;
+        uint8_t log2m = num_of_trail_zeros(data_segment_size);
 
         if (buf[0] != CCARD_ALGO_HYPERLOGLOG ||
             buf[1] != hf ||
@@ -133,7 +137,7 @@ hll_cnt_ctx_t *hll_cnt_init(const void *obuf, uint32_t len_or_k, uint8_t hf)
             return NULL;
         }
 
-        return hll_cnt_raw_init(buf + 3, len_or_k, hf);
+        return hll_cnt_raw_init(buf + 3, data_segment_size, hf);
     }
 
     return hll_cnt_raw_init(NULL, len_or_k, hf);
@@ -440,4 +444,3 @@ const char *hll_cnt_errstr(int err)
 }
 
 // vi:ft=c ts=4 sw=4 fdm=marker et
-

--- a/src/hyperloglogplus_counting.c
+++ b/src/hyperloglogplus_counting.c
@@ -265,7 +265,7 @@ hllp_cnt_ctx_t *hllp_cnt_init(const void *obuf, uint32_t len_or_k)
           return NULL;
         }
         uint32_t data_segment_size = len_or_k - 3;
-        uint8_t log2m = data_segment_size;
+        uint8_t log2m = num_of_trail_zeros(data_segment_size);
 
         if (buf[0] != CCARD_ALGO_HYPERLOGLOGPLUS ||
             buf[1] != hf ||

--- a/src/hyperloglogplus_counting.c
+++ b/src/hyperloglogplus_counting.c
@@ -261,7 +261,11 @@ hllp_cnt_ctx_t *hllp_cnt_init(const void *obuf, uint32_t len_or_k)
 
     if (buf) {
         // initial bitmap was given
-        uint8_t log2m = buf ? num_of_trail_zeros(len_or_k) : len_or_k;
+        if(len_or_k <= 3){
+          return NULL;
+        }
+        uint32_t data_segment_size = len_or_k - 3;
+        uint8_t log2m = data_segment_size;
 
         if (buf[0] != CCARD_ALGO_HYPERLOGLOGPLUS ||
             buf[1] != hf ||
@@ -271,7 +275,7 @@ hllp_cnt_ctx_t *hllp_cnt_init(const void *obuf, uint32_t len_or_k)
             return NULL;
         }
 
-        return hllp_cnt_raw_init(buf + 3, len_or_k);
+        return hllp_cnt_raw_init(buf + 3, data_segment_size);
     }
 
     return hllp_cnt_raw_init(NULL, len_or_k);
@@ -572,4 +576,3 @@ const char *hllp_cnt_errstr(int err)
 }
 
 // vi:ft=c ts=4 sw=4 fdm=marker et
-

--- a/t/hyperloglog_counting_unittest.cc
+++ b/t/hyperloglog_counting_unittest.cc
@@ -228,5 +228,16 @@ TEST(HyperloglogCounting, Merge)
     EXPECT_EQ(rc, 0);
 }
 
-// vi:ft=c ts=4 sw=4 fdm=marker et
+TEST(HyperloglogCounting, Deserialize)
+{
+  hll_cnt_ctx_t * ctx = hll_cnt_init(NULL, 16, CCARD_HASH_MURMUR);
+  EXPECT_NE(ctx, (hll_cnt_ctx_t *)NULL);
+  uint32_t num_bytes = 0;
+  EXPECT_EQ(hll_cnt_get_bytes(ctx, NULL, &num_bytes), 0);
+  uint8_t buf[num_bytes];
+  EXPECT_EQ(hll_cnt_get_bytes(ctx, buf, &num_bytes), 0);
+  hll_cnt_ctx_t * other = hll_cnt_init(buf, num_bytes, CCARD_HASH_MURMUR);
+  EXPECT_NE(other, (hll_cnt_ctx_t *)NULL);
+}
 
+// vi:ft=c ts=4 sw=4 fdm=marker et

--- a/t/hyperloglogplus_counting_unittest.cc
+++ b/t/hyperloglogplus_counting_unittest.cc
@@ -74,3 +74,14 @@ TEST(HyperloglogPlusCounting, Counting)
     EXPECT_EQ(rc, 0);
 }
 
+TEST(HyperloglogPlusCounting, Deserialize)
+{
+  hllp_cnt_ctx_t * ctx = hllp_cnt_init(NULL, 16);
+  EXPECT_NE(ctx, (hllp_cnt_ctx_t *)NULL);
+  uint32_t num_bytes = 0;
+  EXPECT_EQ(hllp_cnt_get_bytes(ctx, NULL, &num_bytes), 0);
+  uint8_t buf[num_bytes];
+  EXPECT_EQ(hllp_cnt_get_bytes(ctx, buf, &num_bytes), 0);
+  hllp_cnt_ctx_t * other = hllp_cnt_init(buf, num_bytes);
+  EXPECT_NE(other, (hllp_cnt_ctx_t *)NULL);
+}


### PR DESCRIPTION
The data loading cases for HyperLogLog and HyperLogLogPlus were not taking into account the 3 byte header when attempting to deserialize via the non-raw init path. The init methods have been adjusted to correctly return `NULL` if the length cannot accommodate a data segment and header, and adjust the downstream length otherwise.

Tests for ensuring that serialization / deserialization roundtrips have also been added.