### PR TITLE
Fix merge_bytes behaviors

### DIFF
--- a/src/hyperloglogplus_counting.c
+++ b/src/hyperloglogplus_counting.c
@@ -405,7 +405,6 @@ int hllp_cnt_merge(hllp_cnt_ctx_t *ctx, hllp_cnt_ctx_t *tbm, ...)
             ctx->err = CCARD_ERR_MERGE_FAILED;
             return -1;
         }
-
         for (i = 1; i < ctx->m; i++) {
             if (tbm->M[i] > ctx->M[i]) {
                 ctx->M[i] = tbm->M[i];
@@ -437,6 +436,7 @@ int hllp_cnt_merge_raw_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len,
     va_list vl;
     uint8_t *in;
     hllp_cnt_ctx_t *bctx;
+    int result;
 
     if (!ctx) {
         return -1;
@@ -450,9 +450,17 @@ int hllp_cnt_merge_raw_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len,
             return -1;
         }
 
-        bctx = hllp_cnt_raw_init(in, ctx->m);
-        hllp_cnt_merge(ctx, bctx, NULL);
+        bctx = hllp_cnt_raw_init(in, len);
+        if(bctx == NULL){
+          ctx->err = CCARD_ERR_MERGE_FAILED;
+          return -1;
+        }
+        result = hllp_cnt_merge(ctx, bctx, NULL);
         hllp_cnt_fini(bctx);
+        if(result != CCARD_OK){
+          ctx->err = CCARD_ERR_MERGE_FAILED;
+          return -1;
+        }
 
         va_start(vl, len);
         while ((in = (uint8_t *)va_arg(vl, const void *)) != NULL) {
@@ -463,9 +471,17 @@ int hllp_cnt_merge_raw_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len,
                 return -1;
             }
 
-            bctx = hllp_cnt_raw_init(in, ctx->m);
-            hllp_cnt_merge(ctx, bctx, NULL);
+            bctx = hllp_cnt_raw_init(in, len);
+            if(bctx == NULL){
+              ctx->err = CCARD_ERR_MERGE_FAILED;
+              return -1;
+            }
+            result = hllp_cnt_merge(ctx, bctx, NULL);
             hllp_cnt_fini(bctx);
+            if(result != CCARD_OK){
+              ctx->err = CCARD_ERR_MERGE_FAILED;
+              return -1;
+            }
         }
         va_end(vl);
     }
@@ -479,11 +495,11 @@ int hllp_cnt_merge_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len, ...
     va_list vl;
     uint8_t *in;
     hllp_cnt_ctx_t *bctx;
+    int result;
 
     if (!ctx) {
         return -1;
     }
-
     if (buf) {
         in = (uint8_t *)buf;
         /* Cannot merge bitmap of different sizes,
@@ -496,9 +512,18 @@ int hllp_cnt_merge_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len, ...
             return -1;
         }
 
-        bctx = hllp_cnt_init(in, ctx->m);
-        hllp_cnt_merge(ctx, bctx, NULL);
+        bctx = hllp_cnt_init(in, len);
+        if(bctx == NULL){
+          ctx->err = CCARD_ERR_MERGE_FAILED;
+          return -1;
+        }
+        result = hllp_cnt_merge(ctx, bctx, NULL);
         hllp_cnt_fini(bctx);
+
+        if(result != CCARD_OK){
+          ctx->err = CCARD_ERR_MERGE_FAILED;
+          return -1;
+        }
 
         va_start(vl, len);
         while ((in = (uint8_t *)va_arg(vl, const void *)) != NULL) {
@@ -512,13 +537,23 @@ int hllp_cnt_merge_bytes(hllp_cnt_ctx_t *ctx, const void *buf, uint32_t len, ...
                 return -1;
             }
 
-            bctx = hllp_cnt_init(in, ctx->m);
-            hllp_cnt_merge(ctx, bctx, NULL);
+            bctx = hllp_cnt_init(in, len);
+            if(bctx == NULL){
+              ctx->err = CCARD_ERR_MERGE_FAILED;
+              return -1;
+            }
+            result = hllp_cnt_merge(ctx, bctx, NULL);
             hllp_cnt_fini(bctx);
+            if(result != CCARD_OK){
+              ctx->err = CCARD_ERR_MERGE_FAILED;
+              break;
+            }
         }
         va_end(vl);
+        if(ctx->err != CCARD_OK){
+          return -1;
+        }
     }
-
     ctx->err = CCARD_OK;
     return 0;
 }

--- a/t/hyperloglogplus_counting_unittest.cc
+++ b/t/hyperloglogplus_counting_unittest.cc
@@ -74,3 +74,40 @@ TEST(HyperloglogPlusCounting, Counting)
     EXPECT_EQ(rc, 0);
 }
 
+TEST(HyperloglogPlusCounting, MergeBytes)
+{
+  hllp_cnt_ctx_t * ctx = hllp_cnt_init(NULL, 10);
+  hllp_cnt_ctx_t * other = hllp_cnt_init(NULL, 10);
+  int64_t i = 1;
+  hllp_cnt_offer(other, &i, sizeof(int64_t));
+  uint8_t buf[1027];
+  uint32_t len = 1027;
+  int result = hllp_cnt_get_bytes(other, buf, &len);
+  EXPECT_EQ(result, 0);
+  result = hllp_cnt_merge_bytes(ctx, buf, 1027, NULL);
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(hllp_cnt_card(ctx), 1);
+}
+
+TEST(HyperloglogPlusCounting, MergeBytesVariadic)
+{
+  hllp_cnt_ctx_t * ctx    = hllp_cnt_init(NULL, 10);
+  hllp_cnt_ctx_t * other1 = hllp_cnt_init(NULL, 10);
+  hllp_cnt_ctx_t * other2 = hllp_cnt_init(NULL, 10);
+  int64_t i = 1;
+  hllp_cnt_offer(other1, &i, sizeof(int64_t));
+  i = 2;
+  hllp_cnt_offer(other2, &i, sizeof(int64_t));
+
+  uint8_t buf1[1027];
+  uint8_t buf2[1027];
+
+  uint32_t len = 1027;
+  int result = hllp_cnt_get_bytes(other1, buf1, &len);
+  EXPECT_EQ(result, 0);
+  result = hllp_cnt_get_bytes(other2, buf2, &len);
+  EXPECT_EQ(result, 0);
+  result = hllp_cnt_merge_bytes(ctx, buf1, 1027, buf2, 1027, NULL);
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(hllp_cnt_card(ctx), 2);
+}


### PR DESCRIPTION
Behaviors that merge based on provided bytes had two bugs:

1. The `hllp` structs used for merging were being passed the `log2m` values as a size, rather than the length of the bitmap. 
1. If an `hllp` merge or initialize operation failed, that failure was not being correctly communicated to the caller.

These should now be fixed.